### PR TITLE
fix: corrections diverses sur les toasts et l'initialisation du player

### DIFF
--- a/.changeset/fix-audio-locked-toasts.md
+++ b/.changeset/fix-audio-locked-toasts.md
@@ -1,0 +1,7 @@
+---
+"nina.fm-website": patch
+---
+
+fix(audio): ne plus afficher les toasts de connexion tant que l'audio n'est pas débloqué
+
+Les toasts "Reconnexion en cours...", "Connexion perdue..." et "Réseau rétabli..." n'apparaissent plus au chargement de la page quand le navigateur bloque l'autoplay (avant que l'utilisateur clique pour lancer la radio).

--- a/.changeset/fix-audio-locked-toasts.md
+++ b/.changeset/fix-audio-locked-toasts.md
@@ -2,6 +2,9 @@
 "nina.fm-website": patch
 ---
 
-fix(audio): ne plus afficher les toasts de connexion tant que l'audio n'est pas débloqué
+Corrections diverses sur les toasts et l'initialisation du player
 
-Les toasts "Reconnexion en cours...", "Connexion perdue..." et "Réseau rétabli..." n'apparaissent plus au chargement de la page quand le navigateur bloque l'autoplay (avant que l'utilisateur clique pour lancer la radio).
+- **fix(audio)** : les toasts de connexion ("Reconnexion en cours...", "Connexion perdue...", "Réseau rétabli...") n'apparaissent plus au chargement quand le navigateur bloque l'autoplay — ils sont supprimés tant que l'utilisateur n'a pas cliqué pour lancer la radio
+- **fix(sonner)** : correction d'une 404 sur `vue-sonner/style.css` en dev — le CSS est maintenant importé directement dans le composant `Sonner.vue` plutôt que via `nuxt.config.ts`
+- **fix(fullscreen)** : suppression du `readonly()` sur le ref `isFullscreen` qui provoquait un Vue warn lors de l'hydratation SSR ("Set operation on key 'value' failed: target is readonly")
+- **fix(debugger)** : remplacement de `v-html` par une interpolation texte dans `AudioDebugger.vue` (élimine le warning ESLint `vue/no-v-html`)

--- a/app/components/common/AudioDebugger.vue
+++ b/app/components/common/AudioDebugger.vue
@@ -45,8 +45,8 @@
               v-for="log in logs"
               :key="log.timestamp"
               class="whitespace-nowrap text-sm before:mr-2 before:content-['▶︎']"
-              v-html="log.message"
-            ></pre>
+              >{{ log.message }}</pre
+            >
             <div ref="bottomEl" class="h-0" />
           </div>
         </div>

--- a/app/components/ui/sonner/Sonner.vue
+++ b/app/components/ui/sonner/Sonner.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
   import { Toaster as Sonner, type ToasterProps } from 'vue-sonner'
+  import 'vue-sonner/style.css'
 
   const props = defineProps<ToasterProps>()
 </script>

--- a/app/composables/useFullscreen.ts
+++ b/app/composables/useFullscreen.ts
@@ -39,7 +39,7 @@ export const useFullscreen = () => {
   })
 
   return {
-    isFullscreen: readonly(isFullscreen),
+    isFullscreen,
     toggle,
   }
 }

--- a/app/stores/audio.ts
+++ b/app/stores/audio.ts
@@ -51,29 +51,31 @@ export const useAudioStore = defineStore('audio', () => {
       reconnecting.value = true
       reconnectAttempts.value = attempt
       log(`Reconnect attempt ${attempt}/${max} in ${delay}ms`)
-      toast.loading('Reconnexion en cours...', { id: 'reconnecting', duration: Infinity })
+      if (!locked.value) toast.loading('Reconnexion en cours...', { id: 'reconnecting', duration: Infinity })
     },
     onMaxAttemptsReached: () => {
       reconnecting.value = false
       log('Max reconnect attempts reached')
-      toast.dismiss('reconnecting')
-      toast.error('Impossible de reconnecter au flux audio. Veuillez recharger la page.', {
-        duration: 10000,
-        action: {
-          label: 'Réessayer',
-          onClick: () => {
-            _resetManager()
-            _attemptReconnect()
+      if (!locked.value) {
+        toast.dismiss('reconnecting')
+        toast.error('Impossible de reconnecter au flux audio. Veuillez recharger la page.', {
+          duration: 10000,
+          action: {
+            label: 'Réessayer',
+            onClick: () => {
+              _resetManager()
+              _attemptReconnect()
+            },
           },
-        },
-      })
+        })
+      }
     },
     onSuccess: () => {
       reconnecting.value = false
       reconnectAttempts.value = 0
       log('Reconnect successful!')
       toast.dismiss('reconnecting')
-      setTimeout(() => toast.success('Connexion au flux audio restaurée', { duration: 3000 }), 100)
+      if (!locked.value) setTimeout(() => toast.success('Connexion au flux audio restaurée', { duration: 3000 }), 100)
     },
   })
 
@@ -216,7 +218,7 @@ export const useAudioStore = defineStore('audio', () => {
     log('Browser back online')
     if (!stopped.value && initialized.value) {
       networkDown.value = true
-      toast.loading('Réseau rétabli. Reconnexion...', { id: 'reconnecting', duration: Infinity })
+      if (!locked.value) toast.loading('Réseau rétabli. Reconnexion...', { id: 'reconnecting', duration: Infinity })
       _resetManager()
       _attemptReconnect()
     }
@@ -232,7 +234,8 @@ export const useAudioStore = defineStore('audio', () => {
         audio.value.removeAttribute('src')
         audio.value.load()
       }
-      toast.loading('Connexion perdue. En attente du réseau...', { id: 'reconnecting', duration: Infinity })
+      if (!locked.value)
+        toast.loading('Connexion perdue. En attente du réseau...', { id: 'reconnecting', duration: Infinity })
     }
   }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
   pinia: {
     storesDirs: ['./app/stores/**', './app/themes/**/stores/**'],
   },
-  css: ['@/assets/css/tailwind.css', 'vue-sonner/style.css'],
+  css: ['@/assets/css/tailwind.css'],
   runtimeConfig: {
     env: process.env.NODE_ENV,
     public: {


### PR DESCRIPTION
## Summary

- **fix(audio)** : les toasts de connexion ("Reconnexion en cours...", "Connexion perdue...", "Réseau rétabli...") n'apparaissent plus au chargement quand le navigateur bloque l'autoplay — supprimés tant que l'utilisateur n'a pas cliqué pour lancer la radio
- **fix(sonner)** : correction d'une 404 sur `vue-sonner/style.css` en dev — import déplacé dans le composant `Sonner.vue` plutôt que via `nuxt.config.ts`
- **fix(fullscreen)** : suppression du `readonly()` sur le ref `isFullscreen` qui provoquait un Vue warn lors de l'hydratation SSR ("Set operation on key 'value' failed: target is readonly")
- **fix(debugger)** : remplacement de `v-html` par une interpolation texte dans `AudioDebugger.vue` (élimine le warning ESLint `vue/no-v-html`)

## Type

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] refactor — code refactoring
- [ ] chore — tooling / config
- [ ] docs — documentation
- [ ] test — tests only

## How to test

1. Ouvrir la page avec l'autoplay bloqué — **aucun toast de connexion ne doit apparaître**
2. Cliquer sur play — les toasts de connexion fonctionnent normalement ensuite
3. Vérifier la console dev : plus de 404 sur `vue-sonner/style.css`
4. Vérifier la console dev : plus de Vue warn "Set operation on key 'value' failed"
5. Vérifier ESLint : 0 erreurs, 0 warnings

## Checklist

- [x] Lint passes (`pnpm lint`)
- [x] Changeset ajouté (`patch`)