### PR TITLE
chore: upgrade Node.js 20 → 22 LTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nina-fm/nina.fm-website
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   test:
@@ -28,7 +29,7 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable
@@ -63,7 +64,7 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile multi-stage pour Nina.fm Website
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 # Enable corepack and pnpm
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
@@ -51,7 +51,7 @@ COPY . .
 RUN pnpm build
 
 # Production stage
-FROM node:20-alpine AS production
+FROM node:22-alpine AS production
 
 # Enable corepack
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate


### PR DESCRIPTION
## Summary

- `Dockerfile` : `node:20-alpine` → `node:22-alpine` (base + production stages)
- CI `deploy.yml` : `node-version: '20'` → `'22'` (jobs `test` + `build-and-deploy`)
- CI `deploy.yml` : ajout de `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` dans l'env global

## Contexte

- Node 20 EOL : avril 2026 — migration nécessaire
- Warning CI GitHub Actions : `actions/checkout@v4` et `actions/setup-node@v4` tournaient sur Node 20, déprécié sur les runners GitHub à partir du 2 juin 2026

## Checklist

- [x] Lint passes
- [ ] Pas de changeset nécessaire (chore)
