### PR TITLE
chore: upgrade actions/checkout et setup-node v4 → v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,17 +17,16 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nina-fm/nina.fm-website
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js and pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -56,13 +55,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.VERSIONING_TOKEN }}
 
       - name: Setup Node.js and pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `@v6` (support Node 24 natif)
- `actions/setup-node@v4` → `@v6` (support Node 24 natif)
- Suppression de `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` devenu inutile

## Contexte

Le flag `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` dans le `env:` workflow ne supprimait pas le warning CI — le runner le génère dès qu'il détecte des actions avec un runtime Node 20, indépendamment du flag. La vraie correction est d'utiliser des versions des actions qui supportent Node 24 nativement (v6).

## Checklist

- [x] Pas de changeset nécessaire (chore CI uniquement)
