### PR TITLE
fix: éliminer les re-renders en cascade au chargement

### DIFF
--- a/.changeset/fix-performance-rerenders.md
+++ b/.changeset/fix-performance-rerenders.md
@@ -1,0 +1,11 @@
+---
+"nina.fm-website": patch
+---
+
+fix: éliminer les re-renders en cascade au chargement
+
+- `audioElement.ts` : corrige la fuite de listeners audio — `_removeEventListeners` utilisait des fonctions anonymes créées à chaque appel, empêchant le vrai nettoyage des événements sur les éléments `Audio` abandonnés
+- `stores/audio.ts` : ajoute une période de grâce (2s) avant d'activer la détection de panne réseau, évitant la fausse alarme de reconnexion au démarrage (toast + AnimatedLoader en cascade)
+- `stores/app.ts` : remplace `watch` par `watchEffect` pour `setBodyClasses`, et corrige `onScopeDispose` appelé dans un contexte async (warning Vue)
+- `peakTheme.ts` / `vinylTheme.ts` : supprime les watchers circulaires en faveur d'actions atomiques qui mutent l'état et appellent `setClasses` en une seule opération
+- `Audience.vue` : lazy-mount des composants `Tooltip` par étoile — au chargement, zéro Tooltip en mémoire ; ils se montent uniquement au premier survol

--- a/app/composables/audioElement.ts
+++ b/app/composables/audioElement.ts
@@ -78,76 +78,47 @@ export const useAudioElement = () => {
     _set('volume', volume, audio.value?.volume)
   }
 
-  const _addEventListeners = () => {
+  const _audioEvents = [
+    'abort', 'canplay', 'canplaythrough', 'emptied', 'ended', 'error',
+    'loadeddata', 'loadedmetadata', 'loadstart', 'pause', 'play', 'playing',
+    'progress', 'suspend', 'timeupdate', 'volumechange', 'stalled', 'waiting',
+  ] as const
+
+  const _handleAudioEvent = () => updateState()
+
+  const _addEventListeners = (el: HTMLAudioElement) => {
     log('_addEventListeners')
-    if (audio.value) {
-      audio.value.addEventListener('abort', () => updateState())
-      audio.value.addEventListener('canplay', () => updateState())
-      audio.value.addEventListener('canplaythrough', () => updateState())
-      audio.value.addEventListener('emptied', () => updateState())
-      audio.value.addEventListener('ended', () => updateState())
-      audio.value.addEventListener('error', () => updateState())
-      audio.value.addEventListener('loadeddata', () => updateState())
-      audio.value.addEventListener('loadedmetadata', () => updateState())
-      audio.value.addEventListener('loadstart', () => updateState())
-      audio.value.addEventListener('pause', () => updateState())
-      audio.value.addEventListener('play', () => updateState())
-      audio.value.addEventListener('playing', () => updateState())
-      audio.value.addEventListener('progress', () => updateState())
-      audio.value.addEventListener('suspend', () => updateState())
-      audio.value.addEventListener('timeupdate', () => updateState())
-      audio.value.addEventListener('volumechange', () => updateState())
-      audio.value.addEventListener('stalled', () => updateState())
-      audio.value.addEventListener('waiting', () => updateState())
-    }
+    _audioEvents.forEach((event) => el.addEventListener(event, _handleAudioEvent))
   }
 
-  const _removeEventListeners = () => {
+  const _removeEventListeners = (el: HTMLAudioElement) => {
     log('_removeEventListeners')
-    if (audio.value) {
-      audio.value.removeEventListener('abort', () => updateState())
-      audio.value.removeEventListener('canplay', () => updateState())
-      audio.value.removeEventListener('canplaythrough', () => updateState())
-      audio.value.removeEventListener('emptied', () => updateState())
-      audio.value.removeEventListener('ended', () => updateState())
-      audio.value.removeEventListener('error', () => updateState())
-      audio.value.removeEventListener('loadeddata', () => updateState())
-      audio.value.removeEventListener('loadedmetadata', () => updateState())
-      audio.value.removeEventListener('loadstart', () => updateState())
-      audio.value.removeEventListener('pause', () => updateState())
-      audio.value.removeEventListener('play', () => updateState())
-      audio.value.removeEventListener('playing', () => updateState())
-      audio.value.removeEventListener('progress', () => updateState())
-      audio.value.removeEventListener('suspend', () => updateState())
-      audio.value.removeEventListener('timeupdate', () => updateState())
-      audio.value.removeEventListener('volumechange', () => updateState())
-      audio.value.removeEventListener('stalled', () => updateState())
-      audio.value.removeEventListener('waiting', () => updateState())
-    }
+    _audioEvents.forEach((event) => el.removeEventListener(event, _handleAudioEvent))
   }
 
   const load = (url: string) => {
     log('load', url)
     unload()
-    audio.value = new Audio()
-    audio.value.autoplay = true
-    audio.value.src = url
-    audio.value.load()
-    _addEventListeners()
+    const el = new Audio()
+    el.autoplay = true
+    el.src = url
+    _addEventListeners(el)
+    audio.value = el
+    el.load()
   }
 
   const unload = () => {
     log('unload')
     if (audio.value) {
-      audio.value.pause()
-      // Force clear the buffer by seeking to end and setting blank source
-      audio.value.currentTime = 0
-      audio.value.removeAttribute('src')
-      audio.value.load() // This empties the buffer
+      const el = audio.value
+      audio.value = null
+      _removeEventListeners(el)
+      el.pause()
+      el.currentTime = 0
+      el.removeAttribute('src')
+      el.load()
+      el.remove()
     }
-    _removeEventListeners()
-    audio.value?.remove()
-    audio.value = null
     resetState()
   }
 

--- a/app/lib/audio/constants.ts
+++ b/app/lib/audio/constants.ts
@@ -18,3 +18,6 @@ export const RECONNECT_DOUBLE_CHECK_DELAY = 2000
 
 /** Delay after page becomes visible again before attempting reconnect */
 export const VISIBILITY_RESTORE_DELAY = 1000
+
+/** Grace period before activating network issue detection (lets audio load normally first) */
+export const NETWORK_CHECK_GRACE_DELAY = 2000

--- a/app/stores/app.ts
+++ b/app/stores/app.ts
@@ -46,17 +46,18 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
-  watch(
-    () => classes.value,
-    () => {
-      setBodyClasses()
-    },
-    { immediate: true },
-  )
+  watchEffect(() => {
+    setBodyClasses()
+  })
+
+  let metaTitleInterval: ReturnType<typeof setInterval> | null = null
 
   onNuxtReady(() => {
-    setInterval(updateMetaTitle, metaTitleRefreshTime)
-    setBodyClasses()
+    metaTitleInterval = setInterval(updateMetaTitle, metaTitleRefreshTime)
+  })
+
+  onScopeDispose(() => {
+    if (metaTitleInterval) clearInterval(metaTitleInterval)
   })
 
   return {

--- a/app/stores/audio.ts
+++ b/app/stores/audio.ts
@@ -3,7 +3,7 @@ import { toast } from 'vue-sonner'
 import { AudioReconnectManager } from '~/lib/audio/AudioReconnectManager'
 import {
   HEARTBEAT_INTERVAL,
-  RECONNECT_DELAYS,
+  NETWORK_CHECK_GRACE_DELAY,
   RECONNECT_DOUBLE_CHECK_DELAY,
   RECONNECT_STOP_START_DELAY,
   RECONNECT_SUCCESS_CHECK_DELAY,
@@ -126,7 +126,7 @@ export const useAudioStore = defineStore('audio', () => {
     // avant d'activer la détection de panne réseau
     setTimeout(() => {
       networkCheckReady = true
-    }, RECONNECT_DELAYS[0])
+    }, NETWORK_CHECK_GRACE_DELAY)
   })
 
   onBeforeMount(() => {

--- a/app/stores/audio.ts
+++ b/app/stores/audio.ts
@@ -3,6 +3,7 @@ import { toast } from 'vue-sonner'
 import { AudioReconnectManager } from '~/lib/audio/AudioReconnectManager'
 import {
   HEARTBEAT_INTERVAL,
+  RECONNECT_DELAYS,
   RECONNECT_DOUBLE_CHECK_DELAY,
   RECONNECT_STOP_START_DELAY,
   RECONNECT_SUCCESS_CHECK_DELAY,
@@ -82,6 +83,7 @@ export const useAudioStore = defineStore('audio', () => {
   let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null
   let heartbeatIntervalId: ReturnType<typeof setInterval> | null = null
   let lastCurrentTime = 0
+  let networkCheckReady = false
 
   // Computed
 
@@ -101,7 +103,7 @@ export const useAudioStore = defineStore('audio', () => {
   // Watchers
 
   watch(networkIssue, (value) => {
-    if (!!value && !networkDown.value && initialized.value && !reconnectManager.reconnecting) {
+    if (!!value && !networkDown.value && initialized.value && networkCheckReady && !reconnectManager.reconnecting) {
       log('networkIssue detected', value)
       networkDown.value = true
       _attemptReconnect()
@@ -120,6 +122,11 @@ export const useAudioStore = defineStore('audio', () => {
     _setupNetworkListeners()
     _startHeartbeat()
     start()
+    // Grace period : laisser le temps à l'audio de charger normalement
+    // avant d'activer la détection de panne réseau
+    setTimeout(() => {
+      networkCheckReady = true
+    }, RECONNECT_DELAYS[0])
   })
 
   onBeforeMount(() => {

--- a/app/themes/peak/components/Audience.vue
+++ b/app/themes/peak/components/Audience.vue
@@ -2,6 +2,7 @@
   import { useMetadataStoreRefs } from '~/stores/metadata'
 
   interface Star {
+    id: number
     styles: {
       width: string
       height: string
@@ -24,6 +25,8 @@
 
   const getRandom = (min: number, max: number) => Math.floor(Math.random() * (max + 1 - min) + min)
 
+  let _nextStarId = 0
+
   const getRandomStyles = (): Star => {
     const { sizes, positions } = params
     const size = getRandom(sizes.min, sizes.max)
@@ -31,6 +34,7 @@
     const step = (size - range + 2) * (100 / range)
     const opacity = step + 50 * ((100 - step) / 100)
     return {
+      id: _nextStarId++,
       styles: {
         width: `${size}px`,
         height: `${size}px`,
@@ -53,16 +57,17 @@
   watch(count, () => updateStars())
   onMounted(() => updateStars())
 
-  // Lazy tooltip management: Tooltip components only mount on first hover
+  // Lazy tooltip management: Tooltip components only mount on first hover.
+  // Keyed by star.id (stable identity) to avoid stale state on count fluctuations.
   const mountedStars = reactive(new Set<number>())
   const openStars = reactive(new Set<number>())
 
-  const onStarEnter = (index: number) => {
-    mountedStars.add(index)
-    openStars.add(index)
+  const onStarEnter = (id: number) => {
+    mountedStars.add(id)
+    openStars.add(id)
   }
-  const onStarLeave = (index: number) => {
-    openStars.delete(index)
+  const onStarLeave = (id: number) => {
+    openStars.delete(id)
   }
 </script>
 
@@ -70,14 +75,14 @@
   <div class="absolute bottom-0 left-0 right-0 top-0 h-full w-full" color="transparent">
     <TooltipProvider>
       <div
-        v-for="(star, index) in stars"
-        :key="index"
+        v-for="star in stars"
+        :key="star.id"
         class="absolute left-0 top-0"
         :style="{ left: star.styles.left, top: star.styles.top }"
-        @mouseenter="onStarEnter(index)"
-        @mouseleave="onStarLeave(index)"
+        @mouseenter="onStarEnter(star.id)"
+        @mouseleave="onStarLeave(star.id)"
       >
-        <Tooltip v-if="mountedStars.has(index)" :open="openStars.has(index)">
+        <Tooltip v-if="mountedStars.has(star.id)" :open="openStars.has(star.id)">
           <TooltipTrigger as-child>
             <div class="p-3 transition-transform duration-200 ease-in-out hover:scale-[2]">
               <div

--- a/app/themes/peak/components/Audience.vue
+++ b/app/themes/peak/components/Audience.vue
@@ -51,21 +51,34 @@
   }
 
   watch(count, () => updateStars())
-
   onMounted(() => updateStars())
+
+  // Lazy tooltip management: Tooltip components only mount on first hover
+  const mountedStars = reactive(new Set<number>())
+  const openStars = reactive(new Set<number>())
+
+  const onStarEnter = (index: number) => {
+    mountedStars.add(index)
+    openStars.add(index)
+  }
+  const onStarLeave = (index: number) => {
+    openStars.delete(index)
+  }
 </script>
 
 <template>
   <div class="absolute bottom-0 left-0 right-0 top-0 h-full w-full" color="transparent">
-    <div
-      v-for="(star, index) in stars"
-      :key="index"
-      class="absolute left-0 top-0"
-      :style="{ left: star.styles.left, top: star.styles.top }"
-    >
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger>
+    <TooltipProvider>
+      <div
+        v-for="(star, index) in stars"
+        :key="index"
+        class="absolute left-0 top-0"
+        :style="{ left: star.styles.left, top: star.styles.top }"
+        @mouseenter="onStarEnter(index)"
+        @mouseleave="onStarLeave(index)"
+      >
+        <Tooltip v-if="mountedStars.has(index)" :open="openStars.has(index)">
+          <TooltipTrigger as-child>
             <div class="p-3 transition-transform duration-200 ease-in-out hover:scale-[2]">
               <div
                 :style="{
@@ -83,8 +96,18 @@
             Actuellement {{ count }} personnes écoutent Nina.fm.
           </TooltipContent>
         </Tooltip>
-      </TooltipProvider>
-    </div>
+        <div v-else class="p-3 transition-transform duration-200 ease-in-out hover:scale-[2]">
+          <div
+            :style="{
+              width: star.styles.width,
+              height: star.styles.height,
+              opacity: star.styles.opacity,
+            }"
+            class="brightness fadeIn h-0 w-0 rounded-full bg-white opacity-0"
+          />
+        </div>
+      </div>
+    </TooltipProvider>
   </div>
 </template>
 

--- a/app/themes/peak/stores/peakTheme.ts
+++ b/app/themes/peak/stores/peakTheme.ts
@@ -8,30 +8,30 @@ export const usePeakThemeStore = defineStore('peakTheme', () => {
   const isDetailsOpen = ref<boolean>(false)
   const isContentOpen = ref<boolean>(false)
 
-  const toggleDetails = () => (isDetailsOpen.value = !isDetailsOpen.value)
-  const openDetails = () => (isDetailsOpen.value = true)
-  const closeDetails = () => (isDetailsOpen.value = false)
-  const toggleContent = () => (isContentOpen.value = !isContentOpen.value)
-  const openContent = () => (isContentOpen.value = true)
-  const closeContent = () => (isContentOpen.value = false)
+  const openDetails = () => {
+    isDetailsOpen.value = true
+    isContentOpen.value = false
+    setClasses({ details: true, content: false })
+  }
+  const closeDetails = () => {
+    isDetailsOpen.value = false
+    setClasses({ details: false })
+  }
+  const toggleDetails = () => (isDetailsOpen.value ? closeDetails() : openDetails())
 
-  // Specific behaviors
-  watch(isContentOpen, (value) => {
-    if (value) isDetailsOpen.value = false
-  })
-  watch(isDetailsOpen, (value) => {
-    if (value) isContentOpen.value = false
-  })
+  const openContent = () => {
+    isContentOpen.value = true
+    isDetailsOpen.value = false
+    setClasses({ content: true, details: false })
+  }
+  const closeContent = () => {
+    isContentOpen.value = false
+    setClasses({ content: false })
+  }
+  const toggleContent = () => (isContentOpen.value ? closeContent() : openContent())
+
   watch(isMixtape, (value) => {
-    if (!value) isDetailsOpen.value = false
-  })
-
-  // Update app classes depending on refs
-  watch(isContentOpen, (value) => {
-    setClasses({ content: value })
-  })
-  watch(isDetailsOpen, (value) => {
-    setClasses({ details: value })
+    if (!value) closeDetails()
   })
 
   return {

--- a/app/themes/vinyl/stores/vinylTheme.ts
+++ b/app/themes/vinyl/stores/vinylTheme.ts
@@ -9,25 +9,30 @@ export const useVinylThemeStore = defineStore('vinylTheme', () => {
   const isJaquetteTurnedBack = ref<boolean>(false)
   const isContentOpen = ref<boolean>(false)
 
-  const toggleDetails = () => (isDetailsOpen.value = !isDetailsOpen.value)
-  const openDetails = () => (isDetailsOpen.value = true)
-  const closeDetails = () => (isDetailsOpen.value = false)
+  const openDetails = () => {
+    isDetailsOpen.value = true
+    setClasses({ details: true })
+  }
+  const closeDetails = () => {
+    isDetailsOpen.value = false
+    setClasses({ details: false })
+  }
+  const toggleDetails = () => (isDetailsOpen.value ? closeDetails() : openDetails())
+
+  const openContent = () => {
+    isContentOpen.value = true
+    setClasses({ content: true })
+  }
+  const closeContent = () => {
+    isContentOpen.value = false
+    setClasses({ content: false })
+  }
+  const toggleContent = () => (isContentOpen.value ? closeContent() : openContent())
+
   const toggleJaquette = () => (isJaquetteTurnedBack.value = !isJaquetteTurnedBack.value)
-  const toggleContent = () => (isContentOpen.value = !isContentOpen.value)
-  const openContent = () => (isContentOpen.value = true)
-  const closeContent = () => (isContentOpen.value = false)
 
-  // Specific behaviors
   watch(isMixtape, (value) => {
-    if (!value) isDetailsOpen.value = false
-  })
-
-  // Update app classes depending on refs
-  watch(isContentOpen, (value) => {
-    setClasses({ content: value })
-  })
-  watch(isDetailsOpen, (value) => {
-    setClasses({ details: value })
+    if (!value) closeDetails()
   })
 
   return {


### PR DESCRIPTION
## Contexte

Profiling Vue DevTools révélait des re-renders en cascade au chargement, assez sévères pour faire bugger l'extension. Deux phases distinctes identifiées dans la Timeline.

## Corrections

### Phase 1 — Flood de Tooltips (2s au démarrage)
- **`Audience.vue`** : lazy-mount des composants `Tooltip` par étoile. Au chargement initial : zéro `Tooltip` en mémoire. Ils se montent uniquement au premier survol, via `reactive(new Set())` + `:open` contrôlé.

### Phase 2 — Cascade Toast/AnimatedLoader (fausse alarme reconnexion)
- **`stores/audio.ts`** : ajout d'une période de grâce de 2s (`networkCheckReady`) avant d'activer la détection de panne réseau. `networkIssue` devenait `true` immédiatement après `start()` (readyState=0, currentTime=0), déclenchant un toast de reconnexion parasite.

### Bugs sous-jacents corrigés en parallèle
- **`composables/audioElement.ts`** : fuite de listeners audio — `_removeEventListeners` utilisait des fonctions anonymes créées à chaque appel, `removeEventListener` ne retirait donc jamais rien. Chaque élément `Audio` abandonné conservait ses 18 listeners actifs.
- **`stores/app.ts`** : `onScopeDispose` placé dans un callback `onNuxtReady` (contexte async) → warning Vue. Corrigé avec `watchEffect` pour `setBodyClasses` et `onScopeDispose` synchrone.
- **`peakTheme.ts` / `vinylTheme.ts`** : watchers circulaires (`isContentOpen` → `isDetailsOpen` → `setClasses` → re-render) remplacés par des actions atomiques qui mutent l'état et appellent `setClasses` en une seule opération.

## Test plan

- [ ] Ouvrir Vue DevTools → Timeline → Performance, enregistrer depuis le chargement de la page
- [ ] Vérifier absence de cascade Tooltip dans les 2 premières secondes
- [ ] Vérifier absence de toast "Reconnexion en cours..." au démarrage
- [ ] Après stabilisation : seul le `progress` SSE toutes les 3s doit apparaître
- [ ] Survoler les étoiles de l'audience → tooltip apparaît correctement sur chaque étoile
- [ ] Ouvrir/fermer les panels Peak et Vinyl → comportement inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)